### PR TITLE
Get-WMIObject was removed in PS6; use Get-CimInstance for PS>=3

### DIFF
--- a/Windows/Apple/Enable-HEIC-Extension-Feature.ps1
+++ b/Windows/Apple/Enable-HEIC-Extension-Feature.ps1
@@ -294,22 +294,9 @@ if (-Not $(Test-NetConnection -InformationLevel Quiet)) {
   exit 1
 }
 
-# some cmdlets got deprecated, so we need to get the current PowerShell version to adapt smoothly
-$psVersionMajor = $PSVersionTable.PSVersion
-if ($psVersionMajor) {
-  $psVersionMajor = $PSVersionTable.PSVersion.Major
-} else {
-  $psVersionMajor = 1
-}
-
 # need to make sure the logged in user is running the script
 $powershellUser = $(whoami)
-if ($psVersionMajor -ge 3) {
-  $loggedInUser = $(Get-CimInstance -ClassName Win32_computerSystem).username.toString()
-} else {
-  # Get-WMIObject was removed in PowerShell 6
-  $loggedInUser = $(Get-WMIObject -class Win32_ComputerSystem).username.toString()
-}
+$loggedInUser = $(Get-CimInstance -ClassName Win32_computerSystem).username.toString()
 if ($powershellUser -ne $loggedInUser) {
   Write-Host "Please make sure the script is running as user (e.g. don't run as admin)."
   exit 1

--- a/Windows/Apple/Enable-HEIC-Extension-Feature.ps1
+++ b/Windows/Apple/Enable-HEIC-Extension-Feature.ps1
@@ -294,9 +294,22 @@ if (-Not $(Test-NetConnection -InformationLevel Quiet)) {
   exit 1
 }
 
+# some cmdlets got deprecated, so we need to get the current PowerShell version to adapt smoothly
+$psVersionMajor = $PSVersionTable.PSVersion
+if ($psVersionMajor) {
+  $psVersionMajor = $PSVersionTable.PSVersion.Major
+} else {
+  $psVersionMajor = 1
+}
+
 # need to make sure the logged in user is running the script
 $powershellUser = $(whoami)
-$loggedInUser = $(Get-WMIObject -class Win32_ComputerSystem).username.toString()
+if ($psVersionMajor -ge 3) {
+  $loggedInUser = $(Get-CimInstance -ClassName Win32_computerSystem).username.toString()
+} else {
+  # Get-WMIObject was removed in PowerShell 6
+  $loggedInUser = $(Get-WMIObject -class Win32_ComputerSystem).username.toString()
+}
 if ($powershellUser -ne $loggedInUser) {
   Write-Host "Please make sure the script is running as user (e.g. don't run as admin)."
   exit 1


### PR DESCRIPTION
Add PowerShell version detection to adapt to removed/added cmdlets

Bonus: Get-CimInstance is faster than Get-WMIObject